### PR TITLE
Lowered the timeout from one minute to a default of 20 seconds

### DIFF
--- a/LuckyMinus20/CVE-2016-2107.go
+++ b/LuckyMinus20/CVE-2016-2107.go
@@ -9,11 +9,11 @@ import (
 	"time"
 )
 
-func Test(address string) (vulnerable bool, err error) {
+func Test(timeOut int, address string) (vulnerable bool, err error) {
 	if _, _, err := net.SplitHostPort(address); err != nil {
 		address = address + ":443"
 	}
-	deadline := time.Now().Add(1 * time.Minute)
+	deadline := time.Now().Add(time.Duration(timeOut) * time.Second)
 	conn, err := tls.DialWithDialer(&net.Dialer{
 		Deadline: deadline,
 	}, "tcp", address, &tls.Config{

--- a/main.go
+++ b/main.go
@@ -3,12 +3,23 @@ package main
 import (
 	"log"
 	"os"
+	"flag"
 
 	"github.com/FiloSottile/CVE-2016-2107/LuckyMinus20"
 )
 
 func main() {
-	res, err := LuckyMinus20.Test(os.Args[1])
+	timeOut := flag.Int("timeout", 20, "Connection timeout in seconds")
+	address := flag.String("address", "127.0.0.1", "Server to test")
+	flag.Parse()
+
+	// Keeps compability with how it worked before command line flags
+	if flag.NArg() == 1 {
+		*address = os.Args[1]
+	}
+
+	res, err := LuckyMinus20.Test(*timeOut, *address)
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
which in my tests proved to be around 10 times the required time to get a response from a patched or vulnerable server - but it of course depends on your network latency.
