### PR TITLE
Exit with error code 2 for vulnerable to make scripting easier

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,6 @@ func main() {
 	}
 	log.Println("Vulnerable:", res)
 	if res {
-		os.Exit(1)
+		os.Exit(2)
 	}
 }


### PR DESCRIPTION
As it happens, the log.fatal() above it will also exit(1)
meaning that from a scripts perspective, you cannot tell the
differance between a failure to connect or whatever, or an actual
postive on the test. Exiting with 2 because ???, I don't know what
else should be exited as.

This closes #3
